### PR TITLE
Updated script to scrap only pages under specified root page

### DIFF
--- a/gitbook_scraper.py
+++ b/gitbook_scraper.py
@@ -33,8 +33,8 @@ def extract_page_links(soup, base_url):
         href = a_tag['href']
         full_url = urllib.parse.urljoin(base_url, href)
         
-        # Check if the URL belongs to the same domain
-        if urllib.parse.urlparse(full_url).netloc == urllib.parse.urlparse(base_url).netloc:
+        # Check if the URL is under the specified root page
+        if full_url.startswith(base_url):
             links.add(full_url)
     return list(links)
 


### PR DESCRIPTION
The following PR updates the script to scrap pages under the specified root page.
The current issue with the script is that it scrapes all pages under the root domain. For example, if the `gitbook_url` is `https://domain.xyz/rootPage/`, the script will scrape all pages under the domain `https://domain.xyz/` instead of scrapping pages under the `rootPage` specified.
The proposed PR fixes the above.